### PR TITLE
Circe improvements

### DIFF
--- a/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
+++ b/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
@@ -2,7 +2,6 @@ package com.reagroup.exercises.circe
 
 import io.circe.Decoder.Result
 import io.circe._
-import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 
 /**
@@ -30,7 +29,6 @@ object CirceExercises {
     * Why is the return type an `Either`?
     */
   def strToJson(str: String): Either[ParsingFailure, Json] = {
-    import io.circe.parser._
     ???
   }
 
@@ -75,17 +73,6 @@ object CirceExercises {
       override def apply(person: Person): Json = ???
     }
     person.asJson(???)
-  }
-
-  /**
-    * There is an alternate way to construct an `Encoder` instance,
-    * by using `Encoder.forProduct2`.
-    *
-    * This may sometimes be simpler than using `Json.obj`.
-    */
-  def encodePersonAgain(person: Person): Json = {
-    implicit val personEncoder: Encoder[Person] = ???
-    person.asJson
   }
 
   /**
@@ -154,16 +141,8 @@ object CirceExercises {
   }
 
   /**
-    * Use `Decoder.forProduct2` to construct a `Decoder` instance
-    * for `Person`.
-    */
-  def decodePersonAgain(json: Json): Either[DecodingFailure, Person] = {
-    implicit val personDecoder: Decoder[Person] = ???
-
-    json.as[Person]
-  }
-
-  /**
+    * You can use "semiauto derivation" for decoders too.
+    *
     * Hint: Use deriveDecoder
     */
   def decodePersonSemiAuto(json: Json): Either[DecodingFailure, Person] = {
@@ -180,12 +159,11 @@ object CirceExercises {
     * Hint: Use `decode`, which does both at the same time.
     */
   def strToPerson(str: String): Either[Error, Person] = {
-    import io.circe.parser._
     import io.circe.generic.semiauto._
 
     implicit val personDecoder: Decoder[Person] = ???
 
-    decode[Person](str)
+    parser.decode[Person](str)
   }
 
 }

--- a/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
+++ b/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
@@ -23,29 +23,14 @@ object CirceExercises {
 
   /**
     * Json Parsing
-    */
-
-  /**
+    *
+    * Hint: `parser` is already in scope (imported through `io.circe._`)
+    *
     * Why is the return type an `Either`?
     */
   def strToJson(str: String): Either[ParsingFailure, Json] = {
     ???
   }
-
-  case class Person(name: String, age: Int)
-
-  /**
-    * Encoding
-    *
-    * Hint: Use `Json.obj()`
-    * Hint: Use `.asJson` to convert Scala standard types to Json
-    *
-    * For more comprehensive examples:
-    * https://circe.github.io/circe/codecs/custom-codecs.html
-    */
-
-  def personToJson(person: Person): Json =
-    ???
 
   /**
     * Try make a syntax error in the following Json document and compile.
@@ -62,16 +47,52 @@ object CirceExercises {
     """
   }
 
+  case class Person(name: String, age: Int)
+
   /**
-    * Create an `Encoder` instance for `Person` by implementing the `apply` method below.
+    * Defining encoders and decoders in the companion object means that Scala will always be able to find them.
+    */
+  case object Person {
+
+    /**
+      * Create an `Encoder` instance for `Person` by implementing the `apply` method below.
+      *
+      * Make `personEncoder` an `implicit` to avoid having to pass the `Encoder` instance
+      * into `asJson` explicitly.
+      */
+    implicit val personEncoder: Encoder[Person] = (p: Person) => {
+      ???
+    }
+
+    /**
+      * Sometimes you might want several encoders for the same type.
+      *
+      * Why can't we define this as implicit as well? How would Scala know which one to pick?
+      */
+    val differentPersonEncoder: Encoder[Person] = (p: Person) => {
+      Json.obj(
+        "different_name" -> p.name.asJson,
+        "different_age" -> p.age.asJson
+      )
+    }
+  }
+
+  /**
+    * Scala will look for an implicit `Encoder[Person]` in the following places:
     *
-    * Make `personEncoder` an `implicit` to avoid having to pass the `Encoder` instance
-    * into `asJson` explicitly.
+    * - The current scope (current method, class, file)
+    * - Imports
+    * - The companion object of `Encoder`
+    * - The companion object of `Person` (bingo!)
     */
   def encodePerson(person: Person): Json = {
-    val personEncoder: Encoder[Person] = new Encoder[Person] {
-      override def apply(person: Person): Json = ???
-    }
+    person.asJson
+  }
+
+  /**
+    * Use `differentPersonEncoder` explicitly to encode the person
+    */
+  def encodePersonDifferently(person: Person): Json = {
     person.asJson(???)
   }
 
@@ -99,10 +120,15 @@ object CirceExercises {
     */
 
   /**
-    * 1. Why is the return type an `Either`?
+    * Remember: `Result[A]` is an alias for `Either[DecodingFailure, A]`
     *
-    * 2. Use the provided `HCursor` to navigate through the `Json`, and try to
-    *    create an instance of `Person`.
+    * Question: Why is the return type an `Either`?
+    *
+    * Construct a `Decoder` instance for `Person`, that uses the `HCursor` to
+    * navigate through the `Json`.
+    *
+    * Use the provided `HCursor` to navigate through the `Json`, and try to
+    * create an instance of `Person`.
     *
     * Hint: Use `cursor.downField("name")` to navigate to the `"name"` field.
     * `cursor.downField("name").as[String]` will navigate to the `"name"` field
@@ -114,17 +140,6 @@ object CirceExercises {
     *
     * For more comprehensive cursor docs:
     * https://circe.github.io/circe/api/io/circe/HCursor.html
-    */
-  def jsonToPerson(json: Json): Either[DecodingFailure, Person] = {
-    val cursor = json.hcursor
-    ???
-  }
-
-  /**
-    * Construct a `Decoder` instance for `Person`, that uses the `HCursor` to
-    * navigate through the `Json`.
-    *
-    * Note: Result[A] is an alias for Either[DecodingFailure, A].
     *
     * For more comprehensive examples:
     * https://circe.github.io/circe/codecs/custom-codecs.html
@@ -135,6 +150,9 @@ object CirceExercises {
     implicit val personDecoder: Decoder[Person] = new Decoder[Person] {
       override def apply(cursor: HCursor): Result[Person] = ???
     }
+    // note: a lot of boilerplate can be removed. Try pressing alt-enter with your
+    // cursor over "new Decoder[Person]" above. This works because Decoder is a trait with
+    // a single abstract method.
 
     // This says "Turn this Json to a Person"
     json.as[Person]
@@ -156,14 +174,14 @@ object CirceExercises {
   /**
     * Parse and then decode
     *
-    * Hint: Use `decode`, which does both at the same time.
+    * Hint: Use `parser.decode`, which does both at the same time.
     */
   def strToPerson(str: String): Either[Error, Person] = {
     import io.circe.generic.semiauto._
 
     implicit val personDecoder: Decoder[Person] = ???
 
-    parser.decode[Person](str)
+    ???
   }
 
 }

--- a/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
+++ b/src/main/scala/com/reagroup/exercises/circe/CirceExercises.scala
@@ -51,6 +51,8 @@ object CirceExercises {
 
   /**
     * Defining encoders and decoders in the companion object means that Scala will always be able to find them.
+    *
+    * Note: they may be "shadowed" by a higher priority implicit
     */
   case object Person {
 
@@ -59,6 +61,15 @@ object CirceExercises {
       *
       * Make `personEncoder` an `implicit` to avoid having to pass the `Encoder` instance
       * into `asJson` explicitly.
+      *
+      * Bonus content (if you have time):
+      *
+      * You can read the code below as "Person is an instance of the Encoder type class"
+      *
+      * More info on type classes:
+      *
+      * - https://typelevel.org/cats/typeclasses.html
+      * - https://www.parsonsmatt.org/2017/01/07/how_do_type_classes_differ_from_interfaces.html
       */
     implicit val personEncoder: Encoder[Person] = (p: Person) => {
       ???

--- a/src/test/scala/com/reagroup/exercises/circe/CirceExercisesSpec.scala
+++ b/src/test/scala/com/reagroup/exercises/circe/CirceExercisesSpec.scala
@@ -47,18 +47,6 @@ class CirceExercisesSpec extends Specification {
 
   }
 
-  "encodePersonAgain" should {
-
-    "convert Person to Json" in {
-      val person = Person("scala", 20)
-      val actual = encodePersonAgain(person)
-      val expected = Json.obj("name" -> "scala".asJson, "age" -> 20.asJson)
-
-      actual must_=== expected
-    }
-
-  }
-
   "encodePersonSemiAuto" should {
 
     "convert Person to Json" in {
@@ -101,24 +89,6 @@ class CirceExercisesSpec extends Specification {
     "convert invalid Json to error" in {
       val json = Json.obj("foo" -> "bar".asJson)
       val errOrPerson = decodePerson(json)
-
-      errOrPerson.isLeft
-    }
-
-  }
-
-  "decodePersonAgain" should {
-
-    "convert valid Json to Person" in {
-      val json = Json.obj("name" -> "scala".asJson, "age" -> 20.asJson)
-      val errOrPerson = decodePersonAgain(json)
-
-      errOrPerson must_=== Right(Person("scala", 20))
-    }
-
-    "convert invalid Json to error" in {
-      val json = Json.obj("foo" -> "bar".asJson)
-      val errOrPerson = decodePersonAgain(json)
 
       errOrPerson.isLeft
     }

--- a/src/test/scala/com/reagroup/exercises/circe/CirceExercisesSpec.scala
+++ b/src/test/scala/com/reagroup/exercises/circe/CirceExercisesSpec.scala
@@ -23,18 +23,6 @@ class CirceExercisesSpec extends Specification {
 
   }
 
-  "personToJson" should {
-
-    "convert Person to Json" in {
-      val person = Person("scala", 20)
-      val actual = personToJson(person)
-      val expected = Json.obj("name" -> "scala".asJson, "age" -> 20.asJson)
-
-      actual must_=== expected
-    }
-
-  }
-
   "encodePerson" should {
 
     "convert Person to Json" in {
@@ -47,6 +35,16 @@ class CirceExercisesSpec extends Specification {
 
   }
 
+  "encodePersonDifferently" should {
+    "convert Person to Json" in {
+      val person = Person("scala", 20)
+      val actual = encodePersonDifferently(person)
+      val expected = Json.obj("different_name" -> "scala".asJson, "different_age" -> 20.asJson)
+
+      actual must_=== expected
+    }
+  }
+
   "encodePersonSemiAuto" should {
 
     "convert Person to Json" in {
@@ -55,24 +53,6 @@ class CirceExercisesSpec extends Specification {
       val expected = Json.obj("name" -> "scala".asJson, "age" -> 20.asJson)
 
       actual must_=== expected
-    }
-
-  }
-
-  "jsonToPerson" should {
-
-    "convert valid Json to Person" in {
-      val json = Json.obj("name" -> "scala".asJson, "age" -> 20.asJson)
-      val errOrPerson = jsonToPerson(json)
-
-      errOrPerson must_=== Right(Person("scala", 20))
-    }
-
-    "convert invalid Json to error" in {
-      val json = Json.obj("foo" -> "bar".asJson)
-      val errOrPerson = jsonToPerson(json)
-
-      errOrPerson.isLeft
     }
 
   }
@@ -90,7 +70,7 @@ class CirceExercisesSpec extends Specification {
       val json = Json.obj("foo" -> "bar".asJson)
       val errOrPerson = decodePerson(json)
 
-      errOrPerson.isLeft
+      errOrPerson must beLeft
     }
 
   }
@@ -108,7 +88,7 @@ class CirceExercisesSpec extends Specification {
       val json = Json.obj("foo" -> "bar".asJson)
       val errOrPerson = decodePersonSemiAuto(json)
 
-      errOrPerson.isLeft
+      errOrPerson must beLeft
     }
 
   }


### PR DESCRIPTION
- Remove `personToJson` and `jsonToPerson` exercises and just go straight to building encoders and decoders
- Remove `forProductN` exercises in the interest of time as these aren't essential to understanding encoders and decoders
- Talk about using the companion object to hold implicits
- Touch on type classes briefly