### PR TITLE
enable wartremover only for compile time.

### DIFF
--- a/wartremover.sbt
+++ b/wartremover.sbt
@@ -1,1 +1,9 @@
-//wartremoverErrors in (Compile, compile) ++= Warts.allBut(Wart.Nothing, Wart.Any, Wart.Recursion)
+wartremoverErrors in (Compile, compile) ++= Warts.allBut(
+  Wart.Nothing,
+  Wart.Any,
+  Wart.Recursion,
+  Wart.FinalCaseClass,
+  Wart.Overloading,
+  Wart.LeakingSealed,
+  Wart.NonUnitStatements,
+)

--- a/wartremover.sbt
+++ b/wartremover.sbt
@@ -1,7 +1,6 @@
 wartremoverErrors in (Compile, compile) ++= Warts.allBut(
   Wart.Nothing,
   Wart.Any,
-  Wart.Recursion,
   Wart.FinalCaseClass,
   Wart.Overloading,
   Wart.LeakingSealed,

--- a/wartremover.sbt
+++ b/wartremover.sbt
@@ -6,4 +6,6 @@ wartremoverErrors in (Compile, compile) ++= Warts.allBut(
   Wart.Overloading,
   Wart.LeakingSealed,
   Wart.NonUnitStatements,
+  Wart.Option2Iterable,
+  Wart.EitherProjectionPartial,
 )


### PR DESCRIPTION
fixes #6 

Selectively turning off some warts to get compilation to run first. 

We can choose to turn on the disabled warts later..

I've tested to ensure that the proposed wartremover settings will get code to compile successfully, and not introduce more failed tests than the master branch currently has :sweat_smile: 