### PR TITLE
Make extensions to sealed types final

### DIFF
--- a/src/main/scala/com/reagroup/appliedscala/config/ConfigError.scala
+++ b/src/main/scala/com/reagroup/appliedscala/config/ConfigError.scala
@@ -10,6 +10,6 @@ object ConfigError {
   }
 }
 
-case class MissingEnvironmentVariable(name: String) extends ConfigError {
+final case class MissingEnvironmentVariable(name: String) extends ConfigError {
   def message: String = s"Missing environment variable: $name"
 }

--- a/src/main/scala/com/reagroup/appliedscala/models/AppError.scala
+++ b/src/main/scala/com/reagroup/appliedscala/models/AppError.scala
@@ -2,4 +2,4 @@ package com.reagroup.appliedscala.models
 
 sealed trait AppError extends Throwable
 
-case class EnrichmentFailure(movieName: String) extends AppError
+final case class EnrichmentFailure(movieName: String) extends AppError

--- a/src/main/scala/com/reagroup/exercises/validated/ValidationExercises.scala
+++ b/src/main/scala/com/reagroup/exercises/validated/ValidationExercises.scala
@@ -26,7 +26,7 @@ object ValidationExercises {
 
   case object PasswordTooWeak extends ValidationError
 
-  case class NameIsEmpty(label: String) extends ValidationError
+  final case class NameIsEmpty(label: String) extends ValidationError
 
   /**
     * If the `name` is empty, return a `NameIsEmpty(label)` in an `Invalid(NonEmptyList(...)`.


### PR DESCRIPTION
This enables us to use the `LeakingSealed` wart after #23 is merged.

Given we wrote this code (and not the students) we should make sure
we use the best practices we can.

From the Wartremover documentation for [LeakingSealed](http://www.wartremover.org/doc/warts.html#leakingsealed):

> Descendants of a sealed type must be final or sealed.
> Otherwise this type can be extended in another file through its
> descendant

There's a similar wart called `FinalCaseClass` that we have disabled
in #23, because it would be annoying for the students to add `final` in
front of every case class they write.