### PR TITLE
Rename optional variable

### DIFF
--- a/src/main/scala/com/reagroup/appliedscala/urls/savereview/SaveReviewService.scala
+++ b/src/main/scala/com/reagroup/appliedscala/urls/savereview/SaveReviewService.scala
@@ -17,7 +17,7 @@ class SaveReviewService(saveReview: (MovieId, ValidatedReview) => IO[ReviewId],
     */
   def save(movieId: MovieId, review: NewReviewRequest): IO[ValidatedNel[ReviewValidationError, ReviewId]] = ???
 
-  private def validateMovie(movieOp: Option[Movie]): ValidatedNel[ReviewValidationError, Movie] = ???
+  private def validateMovie(maybeMovie: Option[Movie]): ValidatedNel[ReviewValidationError, Movie] = ???
 
   private def validateReview(review: NewReviewRequest): ValidatedNel[ReviewValidationError, ValidatedReview] = ???
 


### PR DESCRIPTION
I'm happy for this to be called `maybeMovie` or `movieOption`.  I just don't think it is worth shortening and potentially confusing people about what the `Op` is short for.